### PR TITLE
1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,36 @@ published tag breaks every link to it.
 
 ---
 
+## 1.6.1 — 2026-08-23
+
+The files Obsidian installs were missing from 1.6.0's release, so nobody could install it.
+
+- **`main.js`, `manifest.json` and `styles.css` are attached to the release again.** Obsidian
+  downloads those three directly from the release assets and never opens the zip — the
+  directory's scanner says as much, "All other files will not be downloaded by Obsidian" —
+  so 1.6.0 going out with only `vault-graph-1.6.0.zip` was a release nobody could install
+  or update to. It failed the automated review on exactly that: *the release 1.6.0
+  specified in `manifest.json` is missing the `main.js` file*, and the same for
+  `manifest.json`.
+
+  The cause was narrow. `release.ps1` only ever passed the zip to `gh release create`, and
+  the releases before this were cut **by hand** — where attaching the loose files is simply
+  what one does. 1.6.0 was the script's first real run, which is the first moment the
+  omission could show. The script attaches all four now and **refuses to publish** if any of
+  the three is missing, rather than producing another uninstallable release.
+
+- **`clip-path` swapped for `clip` in the screen-reader-only rule.** The directory's CSS
+  lint flags `clip-path` as only partially supported by Obsidian 1.6.5. This plugin's floor
+  is 1.7.2 so nobody was affected, but a warning that needs a paragraph of explanation is
+  worse than the one-line alternative — and `clip: rect(0 0 0 0)` is what every
+  screen-reader-only helper has used for twenty years.
+
+Nothing else changed: no behaviour, no layout, no colours. 1.6.0's assets were repaired in
+place as well, so that release is installable too; this one exists so the fixes are in a
+tagged commit and the directory has a release to review.
+
+---
+
 ## 1.6.0 — 2026-08-23
 
 **You can choose the colours now**, in both targets, and the palette they come from

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "vault-graph",
   "name": "Vault Graph",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "minAppVersion": "1.7.2",
   "description": "Your whole vault as one disc: notes packed into folder wedges on a fixed lattice, sized by links, with a growth heatmap, timeline, search and per-folder filters. Deterministic, not force-directed - the same vault always draws the same picture.",
   "author": "Lukas Proprentner",

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -155,8 +155,34 @@ try {
   $notesFile = Join-Path $env:TEMP "vg-notes-$Version.md"
   $body = if ($Notes) { "$Notes`n`n$section" } else { $section }
   [IO.File]::WriteAllText($notesFile, $body, $utf8)
+  # THE THREE LOOSE FILES ARE WHAT OBSIDIAN ACTUALLY INSTALLS, and they are not optional.
+  #
+  # Obsidian downloads main.js, manifest.json and styles.css directly from the release
+  # assets. It never opens the zip -- the directory's own scanner says so in as many words,
+  # "All other files will not be downloaded by Obsidian" -- so a release carrying only the
+  # zip is a release nobody can install or update to.
+  #
+  # 1.6.0 shipped exactly that way and the scan came back with two errors: "the release
+  # 1.6.0 specified in manifest.json is missing the main.js file", and the same for
+  # manifest.json. The releases before it looked fine only because they were cut BY HAND
+  # (see the version-regex note above) and attaching the loose files is what one does by
+  # hand. 1.6.0 was this script's first real run, which is when the omission could first
+  # show up.
+  #
+  # The zip stays: it is what someone wanting to RUN the exporter needs, since GitHub's
+  # source archive ships .ai-context/ and the dev tooling. The scanner calls it an extra
+  # unsupported file, which is a recommendation and is the intended trade.
+  $loose = @('main.js', 'manifest.json', 'styles.css') | ForEach-Object { Join-Path $repo $_ }
+  $missing = $loose | Where-Object { -not (Test-Path $_) }
+  if ($missing) {
+    if (-not $tagExists) { & git tag -d $Version | Out-Null }
+    throw ("not attaching an uninstallable release -- missing " +
+           (($missing | Split-Path -Leaf) -join ', ') + ". Run: node scripts/build-plugin.mjs")
+  }
+
   $releaseTitle = if ($Title) { "$Version - $Title" } else { $Version }
-  Invoke-Native $gh @('release', 'create', $Version, $zip, '--title', $releaseTitle, '--notes-file', $notesFile)
+  Invoke-Native $gh (@('release', 'create', $Version) + $loose + @($zip) +
+                     @('--title', $releaseTitle, '--notes-file', $notesFile))
   Remove-Item $notesFile -ErrorAction SilentlyContinue
 
   Write-Host "`nreleased $Version with $(Split-Path $zip -Leaf)" -ForegroundColor Green

--- a/src/page.css
+++ b/src/page.css
@@ -326,10 +326,16 @@
     color: var(--text-1); background: var(--surface-2); border-color: var(--border);
   }
   /* Visible to a screen reader, gone from the layout. Not `display: none`, which
-     takes it out of the accessibility tree along with the layout. */
+     takes it out of the accessibility tree along with the layout.
+
+     The deprecated `clip` rather than `clip-path`, deliberately: the directory's CSS lint
+     flagged clip-path as only partially supported by Obsidian 1.6.5. This plugin's floor is
+     1.7.2 so it would have worked, but a warning that needs a paragraph of explanation is
+     worse than the one-line alternative -- and `clip` is what every screen-reader-only
+     helper has used for twenty years, on the widest support of anything here. */
   .vault-graph .sr {
     position: absolute; width: 1px; height: 1px; overflow: hidden;
-    clip-path: inset(50%); white-space: nowrap;
+    clip: rect(0 0 0 0); white-space: nowrap;
   }
 
   /* One row per top-level folder: its name, then the ten slots under it. Stacked


### PR DESCRIPTION
Patch release: the files Obsidian actually installs were missing from 1.6.0's release.

- `main.js`, `manifest.json` and `styles.css` are attached to the release again, and
  `release.ps1` now refuses to publish without them. 1.6.0 was the script's first real run
  and it only ever passed the zip; the releases before it were cut by hand, where attaching
  the loose files is simply what one does.
- `clip-path` swapped for `clip` in the screen-reader-only rule, clearing the CSS lint
  warning. Invisible change, and the floor is 1.7.2 so nobody was affected either way.

No behaviour, layout or colour change. 1.6.0's assets were repaired in place, so that
release is installable too — this exists so the fixes sit in a tagged commit and the
directory has a real release to review rather than a Preview.
