### PR TITLE
The month in progress draws only the days it has lived, and the strip ends on one of them

### DIFF
--- a/.ai-context/invariants.md
+++ b/.ai-context/invariants.md
@@ -632,7 +632,10 @@ vault is far too tight for a vault whose whole span is 14 months.
 year's own note count against `yearRef` — the same p90-with-floor shape `nRef` already uses
 for bar height, applied here to note count per year instead of per month. Within a year,
 every one of its months gets an equal share of the year's own width — deliberately NOT
-weighted by the month's own note count; that was tried and read as noise.
+weighted by the month's own note count; that was tried and read as noise. The one exception
+is the LAST month, which is the month in progress and takes only the fraction of that equal
+share its elapsed days have earned — see *The strip's right edge is a day the vault has
+reached* below.
 
 ```javascript
 __vg.setCompactAxis(false); __vg.ribbonXOf(ms)   // the untouched linear formula
@@ -715,6 +718,94 @@ shipped, so `onCompactAxis` came back, matching `onPanEnabled`. *the view-level 
 actually flips the live state, and persists* covers it the same way the settings-row check
 covers its own button, and was confirmed against the real plugin under CDP (22px tall, no
 overflow, no overlap with the date fields) rather than assumed from the standalone.
+
+## The strip's right edge is a day the vault has reached
+
+`dateSpan.hi` used to be `Date.UTC(y1, m1 + 1, 0)` — the newest note's month, rounded UP to
+that month's last calendar day (github#51). So the strip's last slice was the month *in
+progress* drawn as if it were over: a full month's share of its year's width, running to a
+date in the future, and scrubbable all the way there.
+
+```javascript
+__vg.dateSpan.hi                                  // the day the strip's right edge means
+new Date(__vg.dateSpan.hi).toISOString().slice(0, 10)
+__vg.ribbonXOf(__vg.dateSpan.hi)                  // == the strip's width, at rest
+```
+
+Measured on a scratch vault written up to the day of the run (2026-09-02, newest note
+2026-09-02, 82 notes over 2025-01 → 2026-09, nine months of 2026 on the strip, 2228px
+strip):
+
+| | before | after |
+|---|---|---|
+| `dateSpan.hi` | **2026-09-30** | **2026-09-02** |
+| 2026-09's share of 2026's width | **11.11%** (104.7px) | **0.83%** (7.3px) |
+| 2026-09 against a complete month in 2026 | **100.0%** | **6.7%** (= 2/30 days) |
+
+So **~97px of that strip — the last 4.3% of the whole control — was days that had not
+happened**, and dragging the right handle across them changed nothing on the disc because
+every one is past the newest note. The readout and the `to` field named them as dates too.
+
+**`hi` is today's local day, clamped on BOTH sides, and the second clamp is not optional.**
+Never before the newest dated note, because a note dated in the future (frontmatter says so,
+and nothing stops it) would otherwise sit past the right edge where no gesture can select it.
+And never past the newest note's own MONTH, because that is the last month the dense month
+grid holds: `monthEndMs` returns `hi` for the last month, so a plain "clamp to today" on a
+vault last written in June and read in September would hand one June segment three months of
+time to interpolate across — and, worse, would compute the pro-rating as *September's*
+day-of-month over *August's* length, collapsing a complete month to 2/31 of its width. All
+three fixtures sat in exactly that state while this was written (generated 2026-08-28, read
+2026-09-02), which is how it was caught.
+
+**Extending the month grid forward to today's month instead was considered and rejected.**
+It would make the right edge mean "now" unconditionally, which is the nicer promise — but the
+cost is unbounded in the other direction: a vault last written years ago would spend years of
+strip on empty months, and on the linear axis (`compactAxis: false`, where there is no
+per-year floor to bound it) the whole informative history would squeeze into a fraction of
+the control. The clamp above never *adds* width, only removes width that was never earned,
+and the dead run it leaves is at most the remainder of one month.
+
+**Both axis paths and both bar layouts inherit this from `buildDateSpan`, by construction.**
+The compact path reads the pro-rated segment widths; the linear path reads the `lo`..`hi`
+those widths are cut from. The linear bar layout was `i * (w / n)` — one equal slice per
+month — while `ribbonXLinear` beside it divided real elapsed time, so a bar and the handle
+standing on it disagreed by up to a day and a half per month even on a vault of whole months
+(February drew as wide as July while the brush treated it as 28/31 of one). Harmless until
+the trailing month stopped running to its own month end, at which point the equal pitch would
+have been the whole bug surviving with compaction off. Now both bar edges come from
+`ribbonXLinear`, so each bar *is* its month's slice. Measured with compaction off on the same
+scratch vault: bars tile with **0 gaps** and end at **2228.0px of 2228.0px**, 2026-02 at
+**102.44px** against 2026-07 at **113.41px** (= 28/31), the trailing 2026-09 at **3.66px**.
+
+**The pro-rating counts days TOUCHED, not whole days elapsed** — the 2nd counts as two, so
+the 1st of a month is 1/31 rather than 0. A zero-width segment is not a rounding detail: the
+brush cannot grab it and `ribbonMsCompact` cannot interpolate inside it (both guard `w1 > w0`
+and fall back to the segment's start), so the strip would lose its right end for a day every
+month.
+
+**The band is deliberately untouched.** It is a rolling window onto `heatParse(TODAY)`, and
+`clampWinEnd` / `winEndCentredAtPx` already refused to scroll past today without going
+through the span at all. The only line of it that reads `hi` is `heatGeom`'s "never wider
+than the vault is old" column clamp, and moving the edge only tightens that toward the truth:
+`lo → hi` is now `lo →` the last day the vault reaches rather than a month end up to thirty
+days in the future, so the clamp can no longer hand the grid weeks of columns before the
+first note.
+
+*the ribbon's right edge is a day the vault has actually reached* asserts all of it: `hi` not
+past today, `hi` not before the newest note, `hi` exactly the day the clamp says, `ribbonXOf(hi)`
+at the strip's own right edge, and the trailing month's segment at exactly its elapsed-day
+fraction of a complete sibling month in the same year. The expected values are restated in the
+check from *today* and *the newest note* — the two facts outside the page — rather than read
+back off `dateSpan.hi`, so a build that got the edge right and the pro-rating wrong cannot
+agree with itself past it. **It goes partly vacuous on a fixture whose last month has since
+ended** (the edge half still asserts; the width half correctly expects 100% and says so in its
+own detail line), which is where all three fixtures sit between regenerations.
+
+**The golden layout snapshots do NOT move.** `dateSpan` is read by the strip, the brush, the
+year chips and the band's column clamp, and by nothing in the disc's layout — the ticket
+expected every checked-in x to shift and it does not, because the snapshots hold node
+positions and band assignment, not axis geometry. Confirmed: *layout matches its golden
+snapshot* passes unchanged on `demo-vault`, 1403 notes, band unchanged, positions unchanged.
 
 ## A note in the hub has left the ring, and the ring closes behind it
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -2985,6 +2985,124 @@ check("compact axis: sparse years cluster near the same floor width", async (p) 
   };
 });
 
+check("the ribbon's right edge is a day the vault has actually reached", async (p) => {
+  // github#51. The span used to end at the newest note's MONTH, rounded up to that month's
+  // last calendar day -- so on the 2nd of September the strip ran to the 30th, and the last
+  // ~93% of its final slice was days that had not happened: scrubbable, named by the range
+  // readout and the `to` field, and changing nothing on the disc because every one of them
+  // is past the newest note. Two halves, both read off the page's own dateSpan and
+  // ribbonXOf and both compared against an expectation restated from today and the newest
+  // note -- the two facts outside the page -- rather than from dateSpan.hi itself:
+  //
+  //   1. THE EDGE IS A REAL DAY -- today, clamped on both sides. Not past today; not before
+  //      the newest dated note (a note dated in the future, because frontmatter says so,
+  //      must stay reachable, and a plain "clamp to today" would leave it past the right
+  //      edge where no gesture can select it); and not past the newest note's own MONTH,
+  //      which is the last month the dense grid holds, so the last segment never has more
+  //      than one month of time to interpolate across.
+  //   2. THE MONTH IN PROGRESS IS PAID FOR ITS ELAPSED DAYS. Its segment is narrower than a
+  //      complete month's in the SAME year -- same year, so the year-weighting divisor
+  //      cancels and what is left is the calendar pro-rating on its own -- by the fraction
+  //      of the month still to come. Asserted against the exact expected ratio rather than
+  //      just "narrower", because "narrower" is also satisfied by a bug that shrinks the
+  //      last month to nothing.
+  //
+  // Needs no fixture of its own and no fixed date -- but note that it is only PARTLY live on
+  // a fixture whose newest note is in a month that has since ended, which is where all three
+  // currently sit (generated 2026-08-28, and the checked-in build is not regenerated daily).
+  // Half 1 still asserts on them; half 2 goes vacuous, correctly expects 100%, and says so
+  // in its own detail line rather than reading as a pass it did not earn. It comes back the
+  // moment the fixtures are regenerated, or on any --vault whose vault was written today.
+  const r = await p.j(`(function(){
+    var d = __vg.dateSpan;
+    if (!d) return { skip: true };
+    // Bare ISO days only, tested by shape rather than by regex -- heatParse is not on __vg,
+    // and a template literal would eat the backslashes of one anyway.
+    var isDay = function (s) {
+      return !!s && s.length === 10 && s.charAt(4) === "-" && s.charAt(7) === "-";
+    };
+    var newest = null;
+    __vg.graph.forEachNode(function (id, a) {
+      if (isDay(a.created) && (newest === null || a.created > newest)) newest = a.created;
+    });
+    var pad = function (n) { return (n < 10 ? "0" : "") + n; };
+    var t = new Date();
+    // TODAY'S LOCAL DAY, built the same way src/page.js builds TODAY -- not toISOString,
+    // which is UTC and would disagree by a day for most of the evening in a +NN zone.
+    var today = t.getFullYear() + "-" + pad(t.getMonth() + 1) + "-" + pad(t.getDate());
+    // The last month's segment against a complete month's in the SAME year. Compared in
+    // WEIGHT units, not pixels: the ratio is the assertion, so converting would only add
+    // rounding to it.
+    var last = d.months.length - 1, lastY = d.months[last].y, lastM = d.months[last].m;
+    var ax = d.axis;
+    var wOf = function (mi) { var s = ax.segs[ax.segOfMonth[mi]]; return s.w1 - s.w0; };
+    var sibling = null, yearW = 0;
+    for (var mi = 0; mi <= last; mi++) if (d.months[mi].y === lastY) {
+      if (sibling === null && mi < last) sibling = mi;
+      yearW += wOf(mi);
+    }
+    return {
+      // The number github#51 was written around: "September holds 1/9 of the year's width
+      // for two days of content, the same slice August gets for thirty-one." Reported, not
+      // asserted -- the ratio against a sibling month above is the same statement with the
+      // year's own month count divided out, and is the one worth failing on.
+      lastShareOfYear: yearW > 0 ? wOf(last) / yearW : 0,
+      lastPx: (wOf(last) / ax.totalW) * document.querySelector("#vg-ribbon").getBoundingClientRect().width,
+      hiISO: new Date(d.hi).toISOString().slice(0, 10),
+      today: today, newest: newest, lastKey: d.months[last].key,
+      monthEndISO: new Date(Date.UTC(lastY, lastM + 1, 0)).toISOString().slice(0, 10),
+      daysIn: new Date(Date.UTC(lastY, lastM + 1, 0)).getUTCDate(),
+      lastW: wOf(last), sibW: sibling === null ? null : wOf(sibling),
+      edgeX: __vg.ribbonXOf(d.hi),
+      w: document.querySelector("#vg-ribbon").getBoundingClientRect().width
+    };
+  })()`);
+  if (r.skip) return { ok: false, detail: "no dateSpan on this vault" };
+  // WHERE THE EDGE SHOULD BE, restated here from the two facts OUTSIDE the page -- today,
+  // and the newest note -- rather than read back off dateSpan.hi. That independence is the
+  // point: with `want` derived from `hi`, a build that got `hi` right and the pro-rating
+  // wrong (or the reverse) could still agree with itself, and the check would pass on a
+  // strip that is half fixed. ISO days compare correctly as strings, so this needs no
+  // parsing.
+  const later = (a, b) => (a > b ? a : b);
+  const earlier = (a, b) => (a < b ? a : b);
+  const wantHi = earlier(r.monthEndISO, later(r.newest || r.today, r.today));
+  const notFuture = r.hiISO <= r.today;
+  const reachesNewest = r.newest === null || r.hiISO >= r.newest;
+  const rightDay = r.hiISO === wantHi;
+  // The span's right end IS the strip's right edge, in pixels -- which is what makes the
+  // brush's "an end at the span's own end means no bound" rule reachable by a hand.
+  const edgeAtEnd = Math.abs(r.edgeX - r.w) <= 1;
+  const elapsed = Number(wantHi.slice(8, 10));
+  const want = elapsed / r.daysIn;
+  const got = r.sibW === null ? null : r.lastW / r.sibW;
+  // 1% of the ratio. The two segments are exact rationals of one another (same year, so the
+  // same yearWeight and the same month count divide both), so float noise is all the slack
+  // this needs.
+  const proRated = got === null || Math.abs(got - want) <= 0.01;
+  const parts = [
+    `span ends ${r.hiISO}, wanted ${wantHi} (today ${r.today}, newest note ` +
+      `${r.newest || "none"}, ${r.lastKey} ends ${r.monthEndISO})`,
+    `right edge at ${r.edgeX.toFixed(1)}px of ${r.w.toFixed(1)}px`,
+    `${r.lastKey} takes ${(r.lastShareOfYear * 100).toFixed(2)}% of ${r.lastKey.slice(0, 4)}'s ` +
+      `width (${r.lastPx.toFixed(1)}px)`,
+    r.sibW === null
+      ? `${r.lastKey} is the only month in ${r.lastKey.slice(0, 4)} -- no complete sibling to compare against`
+      : `${r.lastKey} draws ${(got * 100).toFixed(1)}% of a complete month in the same year, ` +
+        `wanted ${(want * 100).toFixed(1)}% (${elapsed}/${r.daysIn} days reached)` +
+        (elapsed === r.daysIn
+          ? " -- VACUOUS on this vault: its last month is already over, so the pro-rating has nothing to do here"
+          : ""),
+  ];
+  if (!notFuture) parts.push("<- THE SPAN ENDS IN THE FUTURE");
+  if (!reachesNewest) parts.push("<- THE NEWEST NOTE IS PAST THE RIGHT EDGE");
+  if (!rightDay) parts.push("<- THE SPAN DOES NOT END ON THE DAY IT REACHES");
+  if (!edgeAtEnd) parts.push("<- dateSpan.hi IS NOT AT THE STRIP'S RIGHT EDGE");
+  if (!proRated) parts.push("<- THE MONTH IN PROGRESS IS NOT PRO-RATED BY ITS ELAPSED DAYS");
+  return { ok: notFuture && reachesNewest && rightDay && edgeAtEnd && proRated,
+           detail: parts.join("; ") };
+});
+
 check("compact axis: the settings-panel toggle actually flips the live state", async (p) => {
   // A REAL regression check, not a manual one-off: $() prepends "vg-" (src/page.js:103), so
   // a rendered row whose literal id is "opt-<key>" instead of "vg-opt-<key>" leaves

--- a/src/page.js
+++ b/src/page.js
@@ -4512,6 +4512,10 @@ function mountVaultGraph(root, data, deps) {
     // internal month-tick spacing predictable, which the density weighting between YEARS
     // does not need help from.
     //
+    // ONE EXCEPTION TO THE EQUAL SHARE, and it is about the calendar rather than about note
+    // counts: the LAST month is the month in progress, and it takes only the fraction of its
+    // equal share that its elapsed days have earned -- see lastFrac below (github#51).
+    //
     // NOT A NO-OP ON AN EVEN-BY-TIME VAULT ANY MORE. The earlier month-real-duration scheme
     // reduced exactly to the linear formula whenever no month was literally empty; this one
     // does not, because it weighs a YEAR by its content rather than by its calendar length
@@ -4525,6 +4529,47 @@ function mountVaultGraph(root, data, deps) {
     var yMax2 = yCounts.length ? yCounts[yCounts.length - 1] : 1;
     var yP90 = yCounts.length ? yCounts[Math.floor(yCounts.length * 0.9)] : 1;
     var yearRef = Math.max(1, yP90, yMax2 * 0.35);
+    // WHERE THE STRIP'S RIGHT EDGE IS, and it is no longer the last month's last calendar
+    // day (github#51). `hi` used to be Date.UTC(y1, m1 + 1, 0) -- the newest note's month,
+    // rounded UP to its end -- so a strip built on the 2nd of September ran to the 30th:
+    // two days of vault and twenty-eight days of nothing, every one of them scrubbable and
+    // every one of them changing nothing on the disc, because they are all past the newest
+    // note. The readout and the `to` field offered those days as dates too, and the eye
+    // reads the right edge as "now", so the vault always looked like it had stopped writing
+    // a few weeks ago.
+    //
+    // TODAY'S LOCAL DAY, bounded on both sides:
+    //
+    //   * NEVER BEFORE THE NEWEST NOTE. A note dated in the future -- frontmatter says so,
+    //     and nothing stops it -- must stay reachable, and today's date alone would leave it
+    //     past the right edge where no gesture can select it.
+    //   * NEVER PAST THE NEWEST NOTE'S OWN MONTH, because that is the last month the dense
+    //     grid above holds. monthEndMs returns `hi` for the last month, so letting `hi` run
+    //     to today on a vault last written in June and read in September would hand that one
+    //     June segment three months of time to interpolate across -- a worse lie than the
+    //     one being fixed. And it would not be worth telling: every day of June HAS happened,
+    //     so a full-width June running to the 30th is already the truth, and the empty days
+    //     between the last note and the month's end are a real gap worth seeing. Which is
+    //     also why `lastFrac` below comes out at exactly 1 in that case and changes nothing.
+    //
+    // The dead run at the right edge is now bounded by how long since you last wrote, at
+    // most to the end of that month, instead of by where the calendar month happens to end.
+    // TODAY is read at load rather than baked in at build time (see its own definition), so
+    // this edge moves on its own overnight -- the same property the band's today marker has.
+    var lastMonthEnd = Date.UTC(y1, m1 + 1, 0);
+    var endMs = Math.min(lastMonthEnd, Math.max(hi, heatParse(TODAY)));
+    // THE MONTH IN PROGRESS IS PAID FOR THE DAYS IT HAS LIVED, as a fraction of the equal
+    // share it would get if it were over. September on the 2nd is a sliver; on the 28th it
+    // is nearly a full month. Exactly 1 for a month that has ended, which is every month but
+    // the last -- and the last one too, the moment it finishes.
+    //
+    // DAYS TOUCHED, not whole days elapsed: the 2nd counts as two, so the 1st of the month
+    // is 1/31 rather than 0. A zero-width segment is not a rounding detail here -- it is a
+    // month the brush cannot grab and ribbonMsCompact cannot interpolate inside (both guard
+    // w1 > w0 and fall back to the segment's start), so the strip would lose its right end
+    // for a day every month. It also makes this the more generous of the two readings by
+    // one day, which is the right direction for a control you have to be able to touch.
+    var lastFrac = new Date(endMs).getUTCDate() / new Date(lastMonthEnd).getUTCDate();
     var segs = [], segW = 0, segOfMonth = new Array(months.length);
     ylist.forEach(function (yy) {
       var yFrac = Math.min(1, yy.n / yearRef);
@@ -4534,13 +4579,26 @@ function mountVaultGraph(root, data, deps) {
       var mw = yearWeight / idxs.length;
       idxs.forEach(function (mi) {
         segOfMonth[mi] = segs.length;
-        segs.push({ i: mi, w0: segW, w1: segW + mw });
-        segW += mw;
+        // The pro-rating happens HERE and nowhere else, because both axis paths and both bar
+        // layouts read these segment widths (or, on the linear path, the `lo`..`hi` these
+        // widths are cut from) -- putting it in the drawing would leave the brush, the year
+        // chips and the bars each holding their own idea of where September ends (github#51).
+        //
+        // The width the month in progress does not take is NOT redistributed to the year's
+        // other months: the year is partly unlived and should draw that way. Stretching
+        // January..August to cover September's missing twenty-eight days would move eleven
+        // complete months' pitch to describe something that happened to the twelfth, and the
+        // equal-share-within-a-year rule above is a promise about COMPLETE months.
+        var mwOwn = mw * (mi === months.length - 1 ? lastFrac : 1);
+        segs.push({ i: mi, w0: segW, w1: segW + mwOwn });
+        segW += mwOwn;
       });
     });
     dateSpan = {
       months: months, years: ylist, index: index,
-      lo: months[0].ms, hi: Date.UTC(y1, m1 + 1, 0),      // last day of the last month
+      // hi is a day the vault has actually reached, not the last month's calendar end --
+      // see the long note above lastMonthEnd (github#51).
+      lo: months[0].ms, hi: endMs,
       nMax: nMax, nRef: nRef, yMax: yMax, dated: tot,
       undated: graph.order - tot,
       axis: { segs: segs, totalW: segW || 1, segOfMonth: segOfMonth }
@@ -10445,6 +10503,16 @@ function mountVaultGraph(root, data, deps) {
   //
   // Bounded by the vault's own span, because a window reaching past the first note is empty
   // columns pretending to be data.
+  //
+  // THE BAND IS DELIBERATELY NOT CHANGED BY github#51, and this is the only line of it that
+  // even reads dateSpan.hi. The band is a rolling window onto TODAY -- heatBuild anchors it
+  // at heatParse(TODAY), clampWinEnd and winEndCentredAtPx already refuse to scroll past
+  // today, and none of that went through the span. So the strip's right edge moving does not
+  // move the band; it only tightens this clamp, and tightens it toward the truth: `hi` used
+  // to be a calendar month's end up to thirty days in the future, so "never wider than the
+  // vault is old" measured the vault as older than it was and could hand the grid a few
+  // weeks of columns before the first note. lo -> hi is now lo -> the last day the vault
+  // reaches, which is the span the window can actually be scrolled across.
   function heatGeom() {
     var wrap = $("heatwrap");
     var avail = ((wrap && wrap.clientWidth) || $("stage").clientWidth || 900) - HEAT_GUTTER;
@@ -11215,8 +11283,17 @@ function mountVaultGraph(root, data, deps) {
     return Math.max(0, Math.min(dateSpan.months.length - 1, idx));
   }
   // The end of month `i`'s ms range -- the next month's start, or dateSpan.hi itself when
-  // `i` is the last month (which is always populated: dateSpan.hi is derived FROM its last
-  // note, so nothing is ever dated past it).
+  // `i` is the last month.
+  //
+  // WHAT THAT MEANS FOR THE LAST MONTH CHANGED (github#51). This used to claim dateSpan.hi
+  // "is derived FROM its last note, so nothing is ever dated past it", and the claim was
+  // false as written: it was derived from that note's MONTH, rounded up, and the month's own
+  // end is up to thirty days PAST the note. The conclusion happened to hold, for the wrong
+  // reason. It still holds, for a reason worth stating plainly: `hi` is today's day floored
+  // at the newest note, so a future-dated note lands inside this segment rather than past
+  // it, and the segment stops where the calendar has actually got to rather than where the
+  // month will eventually end. So the last month is the one month whose ms range is SHORTER
+  // than the calendar month it names -- which is exactly the width buildDateSpan pays it.
   function monthEndMs(i) {
     return (i + 1 < dateSpan.months.length) ? dateSpan.months[i + 1].ms : dateSpan.hi;
   }
@@ -11336,16 +11413,31 @@ function mountVaultGraph(root, data, deps) {
         cx.fillRect((jSeg.w0 / totalW) * w, 0, 1, top);
       }
     } else {
-      var pitch = w / n;
+      // PLACED BY THE SAME MAPPING THE BRUSH USES ON THIS AXIS, not at an equal pitch.
+      //
+      // It was `i * (w / n)`, one equal slice per month, while ribbonXLinear right beside it
+      // divided REAL ELAPSED TIME -- so a bar and the handle standing on it disagreed by up
+      // to a day and a half of width per month even on a vault of nothing but whole months
+      // (February drew as wide as July while the brush treated it as 28/31 of one). Harmless
+      // enough to have gone unnoticed; not harmless once the trailing month stopped running
+      // to its own month end, which is what github#51 changed: the month in progress would
+      // have kept a full month's bar under a strip that no longer reaches that far, and the
+      // equal pitch would have been the whole of the old bug surviving with compaction off.
+      //
+      // Asking ribbonXLinear for both edges makes each bar BE its month's slice of the span,
+      // so the partial month draws short on this path for the same reason it does on the
+      // compact one -- from the single change in buildDateSpan, with no second copy of the
+      // pro-rating here.
       for (var i = 0; i < n; i++) {
-        paintMonthBar(cx, top, ms[i], i * pitch, Math.max(1, pitch - 0.6));
+        var bx = ribbonXLinear(ms[i].ms, w);
+        paintMonthBar(cx, top, ms[i], bx, Math.max(1, ribbonXLinear(monthEndMs(i), w) - bx - 0.6));
       }
       // Year boundaries. Only January gets a rule, so the strip reads as years rather than as
       // 121 months. The years themselves are named by the buttons below -- see buildYears.
       for (var j2 = 0; j2 < n; j2++) {
         if (ms[j2].m !== 0) continue;
         cx.fillStyle = rgbaHex(css("--text-3"), 0.28);
-        cx.fillRect(j2 * pitch, 0, 1, top);
+        cx.fillRect(ribbonXLinear(ms[j2].ms, w), 0, 1, top);
       }
     }
 


### PR DESCRIPTION
Closes #51. The strip's right edge is now a day the vault has actually reached, and the month in progress takes only the fraction of its equal share that its elapsed days have earned. Golden snapshots unchanged on all three fixtures.

| | before | after |
|---|---|---|
| `dateSpan.hi` (built 2026-09-02) | 2026-09-30 | 2026-09-02 |
| trailing month's share of its year | 11.11% (104.7px) | 0.83% (7.3px) |
| vs a complete month | 100% | 6.7% (= 2/30 days) |

One clamp more than the ticket asked for: `hi` is today, floored at the newest note and capped at the newest note's own month end. Without the cap, a vault last written in June and read in September hands one June segment three months to interpolate across. Reasoning in the commit body and at the line.

Also fixes a pre-existing disagreement on the plain-calendar bar layout, which drew every month at `w / n` while the brush beside it divided real elapsed time.

New invariant check: *the ribbon's right edge is a day the vault has actually reached*. Partly vacuous on the checked-in fixtures until they are regenerated, and says so in its detail line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
