### PR TITLE
Cut 2.4.1: README docs links, Pages enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ published tag breaks every link to it.
 
 ---
 
+## 2.4.1 — 2026-09-10
+
+**The README's "Try it live" and feature-list links now go somewhere.** 2.4.0 shipped the docs
+as a real site but the README still carried the placeholder line from before the site resolved —
+"this line gets its links the moment it's live" — and GitHub Pages itself had never been switched
+on for the repository, so there was nothing to link to. Pages is enabled now, serving from
+`main`'s `docs/`, and the README points at it: [the live
+demo](https://luke321.github.io/vault-graph/demo/), [the feature
+gallery](https://luke321.github.io/vault-graph/features.html), and [the site
+itself](https://luke321.github.io/vault-graph/). Nothing in the plugin changed.
+
+---
+
 ## 2.4.0 — "Auto" — 2026-09-10
 
 **Write a note, link three people, and the disc beside you notices.** Refresh used to be the

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ ringed by how well-connected they are. Click a folder to hide it and the rest re
 a note to see its links; search narrows to matching notes; scrub a date ribbon to watch the
 vault grow. Follows Obsidian's theme, including a live switch.
 
-**Try it live** — a real export of an invented 1,400-note vault, click and hover it exactly like
-your own. The full feature list, one short clip per feature — the disc itself, filtering, the
-heatmap and timeline, reading a note, the camera, and folder colours — is a click away too. Both
-are going up as a proper site; this line gets its links the moment it's live.
+**[Try it live](https://luke321.github.io/vault-graph/demo/)** — a real export of an invented
+1,400-note vault, click and hover it exactly like your own. **[The full feature
+list](https://luke321.github.io/vault-graph/features.html)**, one short clip per feature — the
+disc itself, filtering, the heatmap and timeline, reading a note, the camera, and folder
+colours — is a click away too. Both live on the
+[docs site](https://luke321.github.io/vault-graph/).
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "vault-graph",
   "name": "Vault Graph",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "minAppVersion": "1.7.2",
   "description": "Your whole vault as one disc: notes packed into folder wedges on a fixed lattice, sized by links, with a growth heatmap, timeline, search and per-folder filters. Deterministic, not force-directed - the same vault always draws the same picture.",
   "author": "Lukas Proprentner",


### PR DESCRIPTION
Hotfix on top of 2.4.0. The README's "Try it live" and feature-list links were still the pre-site placeholder, and GitHub Pages had never been enabled for the repo. Pages is on now (main, /docs); the README links to the live demo, the feature gallery and the site. Docs only — nothing in the plugin changed. manifest.json at 2.4.1, CHANGELOG has the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKvNkN492zeVWuDYfzWDC2